### PR TITLE
Detect file extension

### DIFF
--- a/lib/headown.rb
+++ b/lib/headown.rb
@@ -2,5 +2,10 @@ require 'headown/version'
 require 'headown/cli'
 
 module Headown
-  class Error < StandardError; end # Your code goes here...
+  class NotMarkdownError < StandardError
+    def initialize(file_path:)
+      msg = "#{file_path} is not a Markdown file."
+      super(msg)
+    end
+  end
 end

--- a/lib/headown/cli.rb
+++ b/lib/headown/cli.rb
@@ -7,8 +7,15 @@ module Headown
     desc 'extract <path>', 'extract headers from file path'
 
     def extract(file_path)
+      raise Headown::NotMarkdownError.new(file_path: file_path) if File.extname(file_path) != '.md'
+
       file_data = URI.open(file_path, &:read)
       puts_headers(file_data)
+    rescue Headown::NotMarkdownError => e
+      puts <<~MSG
+      #{e.class}:
+        #{e.message}
+      MSG
     end
 
     private

--- a/spec/headown/cli_spec.rb
+++ b/spec/headown/cli_spec.rb
@@ -48,4 +48,16 @@ RSpec.describe Headown::CLI do
       end
     end
   end
+
+  describe 'Headown::NotMarkdownError' do
+    let(:file_path) { 'spec/headown/non-md.html' }
+    context "#{file_path} is passed" do
+      it do
+        expect { raise Headown::NotMarkdownError.new(file_path: file_path) }.to raise_error(
+          Headown::NotMarkdownError,
+          "#{file_path} is not a Markdown file."
+        )
+      end
+    end
+  end
 end

--- a/spec/headown/cli_spec.rb
+++ b/spec/headown/cli_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe Headown::CLI do
   end
 
   describe 'Headown::NotMarkdownError' do
-    let(:file_path) { 'spec/headown/non-md.html' }
-    context "#{file_path} is passed" do
+    let(:html_file) { 'spec/headown/non-md.html' }
+    context 'when path to html is passed' do
       it do
-        expect { raise Headown::NotMarkdownError.new(file_path: file_path) }.to raise_error(
+        expect { raise Headown::NotMarkdownError.new(file_path: html_file) }.to raise_error(
           Headown::NotMarkdownError,
-          "#{file_path} is not a Markdown file."
+          "#{html_file} is not a Markdown file."
         )
       end
     end


### PR DESCRIPTION
When you pass the file path which does not have `.md` extension, it gets an error.

```sh
❯ bundle exec exe/headown extract headown.gemspec 
Headown::NotMarkdownError:
  headown.gemspec is not a Markdown file.
```
