### PR TITLE
Move require 'headown/cli' to exe/headown

### DIFF
--- a/exe/headown
+++ b/exe/headown
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
-require "headown"
+require 'headown'
+require 'headown/cli'
 
 Headown::CLI.start(ARGV)

--- a/lib/headown.rb
+++ b/lib/headown.rb
@@ -1,5 +1,4 @@
 require 'headown/version'
-require 'headown/cli'
 
 module Headown
   class NotMarkdownError < StandardError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'headown'
+require 'headown/cli'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
and require in spec/spec_helper.rb

Preparation for separating the CLI and logic portions